### PR TITLE
Propagate program and team in SNS and SQS messages

### DIFF
--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -1,7 +1,7 @@
 class Check < ApplicationRecord
-  # checktype_name and program_team are virtual attributes, not persisted in the model.
+  # checktype_name and metadata are virtual attributes, not persisted in the model.
   attr_accessor :checktype_name
-  attr_accessor :program_team
+  attr_accessor :metadata
 
   include Filterable
   include AASM

--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -1,6 +1,7 @@
 class Check < ApplicationRecord
-  # checktype_name is a virtual attribute, not persisted in the model.
+  # checktype_name and program_team are virtual attributes, not persisted in the model.
   attr_accessor :checktype_name
+  attr_accessor :program_team
 
   include Filterable
   include AASM

--- a/lib/scans_helper.rb
+++ b/lib/scans_helper.rb
@@ -27,7 +27,7 @@ class ScansHelper
       return
     end
     metadata = self.get_metadata(scan)
-    program_team = "#{metadata[:program]}-#{metadata[:team]}"
+    program_team = "#{metadata[:team]}-#{metadata[:program]}"
     metric_tags = ["scan:#{program_team}","scanstatus:#{scanstatus}"]
     Metrics.count("scan.count", 1, metric_tags)
   end

--- a/lib/scans_helper.rb
+++ b/lib/scans_helper.rb
@@ -1,39 +1,33 @@
 require 'uuid'
 class ScansHelper
-  def self.get_program_team(scan)
-    scan_label = "unknown-program"
-    team_label = "unknown-team"
+  def self.get_metadata(scan)
+    metadata = {
+      "team" => "unknown-team",
+      "program" => "unknown-program"
+    }
     if scan.nil?
-      Rails.logger.warn "error obtaining program_team for nil scan"
-      return "#{team_label}-#{scan_label}"
+      Rails.logger.warn "error obtaining scan metadata for nil scan"
+      return metadata
     end
     if scan[:program].blank?
-      Rails.logger.warn "error obtaining program name for scan [#{scan.id}]"
+      Rails.logger.warn "error obtaining program metadata for scan [#{scan.id}]"
     else
-      scan_label = scan[:program].downcase
+      metadata["program"] = scan[:program].downcase
     end
     if scan[:tag].blank?
-      Rails.logger.warn "error obtaining team name for scan [#{scan.id}]"
+      Rails.logger.warn "error obtaining team metadata for scan [#{scan.id}]"
     else
-      team_label = scan[:tag].split(':').last.downcase
+      metadata["team"] = scan[:tag].split(':').last.downcase
     end
-    return "#{team_label}-#{scan_label}"
-  end
-
-  def self.get_program_team_by_scan_id(scan_id)
-    if scan_id
-      scan = Scan.find(scan_id)
-      return self.get_program_team(scan)
-    end
-    return self.get_program_team(nil)
+    return metadata
   end
 
   def self.push_metric(scan,scanstatus="running")
     unless Rails.application.config.metrics
       return
     end
-    program_team = self.get_program_team(scan)
-
+    metadata = self.get_metadata(scan)
+    program_team = "#{metadata[:program]}-#{metadata[:team]}"
     metric_tags = ["scan:#{program_team}","scanstatus:#{scanstatus}"]
     Metrics.count("scan.count", 1, metric_tags)
   end

--- a/lib/sns_service.rb
+++ b/lib/sns_service.rb
@@ -13,14 +13,16 @@ class SNSService
     object_type = object.class.name.demodulize
     message = object.to_json
     if object_type == "Check"
-      program_team = ScansHelper.get_program_team_by_scan_id(object.scan_id)
-      object.program_team = program_team
+      if object.scan_id
+        scan = Scan.find(object.scan_id)
+      end
+      object.metadata = ScansHelper.get_metadata(scan)
       checktype = Checktype.find(object.checktype_id)
       unless checktype.nil?
         # using Check's checktype_name virtual attribute.
         object.checktype_name = checktype.name
       end
-      message = object.to_json(methods: [:checktype_name, :program_team])
+      message = object.to_json(methods: [:checktype_name, :metadata])
     end
     status = "UNKNOWN"
     begin

--- a/lib/sns_service.rb
+++ b/lib/sns_service.rb
@@ -13,12 +13,14 @@ class SNSService
     object_type = object.class.name.demodulize
     message = object.to_json
     if object_type == "Check"
+      program_team = ScansHelper.get_program_team_by_scan_id(object.scan_id)
+      object.program_team = program_team
       checktype = Checktype.find(object.checktype_id)
       unless checktype.nil?
         # using Check's checktype_name virtual attribute.
         object.checktype_name = checktype.name
-        message = object.to_json(methods: :checktype_name)
       end
+      message = object.to_json(methods: [:checktype_name, :program_team])
     end
     status = "UNKNOWN"
     begin

--- a/lib/sqs_service.rb
+++ b/lib/sqs_service.rb
@@ -12,6 +12,7 @@ class SQSService
     resp = @sqs.get_queue_url({
       queue_name: check.queue_name,
     })
+    program_team = ScansHelper.get_program_team_by_scan_id(check.scan_id)
     Rails.logger.debug "SQSService: Target queue #{resp.queue_url}"
     check_message = {
       "check_id" => check.id,
@@ -21,6 +22,7 @@ class SQSService
       "options" => check.options,
       "required_vars" => check.required_vars,
       "scan_id" => check.scan_id,
+      "program_team" => program_team,
       "start_time" => start_time
     }
 

--- a/lib/sqs_service.rb
+++ b/lib/sqs_service.rb
@@ -12,7 +12,10 @@ class SQSService
     resp = @sqs.get_queue_url({
       queue_name: check.queue_name,
     })
-    program_team = ScansHelper.get_program_team_by_scan_id(check.scan_id)
+    if check.scan_id
+      scan = Scan.find(check.scan_id)
+    end
+    metadata = ScansHelper.get_metadata(scan)
     Rails.logger.debug "SQSService: Target queue #{resp.queue_url}"
     check_message = {
       "check_id" => check.id,
@@ -22,7 +25,7 @@ class SQSService
       "options" => check.options,
       "required_vars" => check.required_vars,
       "scan_id" => check.scan_id,
-      "program_team" => program_team,
+      "metadata" => metadata,
       "start_time" => start_time
     }
 


### PR DESCRIPTION
This PR adds check metadata (program-team) to SQS and SNS messages in order to be able to correlate metrics related to tenants in different Vulcan components.