### PR TITLE
Add assettype optional attribute to checks

### DIFF
--- a/app/controllers/api/v1/checks_controller.rb
+++ b/app/controllers/api/v1/checks_controller.rb
@@ -97,7 +97,7 @@ module Api::V1
     def check_params
       # NOTE: the :check definition should be in sync with its definition in the
       # ScansController and the scan processor in lib/scan_processor.rb.
-      params.require(:check).permit(:target, :status, :options, :webhook, :agent_id, :checktype_id, :checktype_name, :progress, :raw, :report, :scan_id, :jobqueue_id, :jobqueue_name, :tag, :required_vars => [])
+      params.require(:check).permit(:target, :status, :options, :webhook, :agent_id, :checktype_id, :checktype_name, :progress, :raw, :report, :scan_id, :jobqueue_id, :jobqueue_name, :tag, :assettype, :required_vars => [])
     end
 
     # Notifies action to stream

--- a/app/controllers/api/v1/scans_controller.rb
+++ b/app/controllers/api/v1/scans_controller.rb
@@ -21,7 +21,7 @@ module Api::V1
     # GET /scans/1/checks
     def checks
       @checks = Check.includes(:checktype).where(deleted_at: nil, scan_id: @scan.id).
-        filter(params.slice(:status, :target, :checktype_id, :agent_id))
+        filter(params.slice(:status, :target, :checktype_id, :agent_id, :assettype))
 
       render json: @checks, :each_serializer => SimpleCheckSerializer
     end
@@ -91,7 +91,7 @@ module Api::V1
     # Only allow a trusted parameter "white list" through.
     def scan_params
       # NOTE: the :check definition should be in sync with its definition in the ChecksController.
-      params.permit(:scan => [ :tag, :program_id, :checks => [ :check => [ :checktype_id, :checktype_name, :target, :options, :webhook, :jobqueue_id, :jobqueue_name, :tag, :required_vars => [] ] ] ])
+      params.permit(:scan => [ :tag, :program_id, :checks => [ :check => [ :checktype_id, :checktype_name, :target, :options, :webhook, :jobqueue_id, :jobqueue_name, :tag, :assettype, :required_vars => [] ] ] ])
     end
 
     # Notifies action to stream

--- a/app/jobs/checks_create_enqueue_job.rb
+++ b/app/jobs/checks_create_enqueue_job.rb
@@ -5,7 +5,7 @@ class ChecksCreateEnqueueJob < ApplicationJob
     checks_params = params[:scan][:checks]
     Rails.logger.info "creating checks for scan_id #{scan_id}"
     checks_params.each do |check_params|
-      whitelisted_check_params = check_params[:check].slice(:checktype_id, :checktype_name, :target, :options, :webhook, :jobqueue_id, :jobqueue_name, :tag, :required_vars => [])
+      whitelisted_check_params = check_params[:check].slice(:checktype_id, :checktype_name, :target, :options, :webhook, :jobqueue_id, :jobqueue_name, :tag, :assettype, :required_vars => [])
       whitelisted_check_params.permit!
       check = ChecksHelper.create_check(whitelisted_check_params.to_h, scan_id)
       if check.nil?

--- a/app/serializers/api/v1/check_serializer.rb
+++ b/app/serializers/api/v1/check_serializer.rb
@@ -2,7 +2,7 @@ module Api::V1
   class CheckSerializer < ActiveModel::Serializer
     include Rails.application.routes.url_helpers
 
-    attributes :id, :target, :status, :options, :webhook, :progress, :raw, :report, :queue_name, :tag
+    attributes :id, :target, :status, :options, :webhook, :progress, :raw, :report, :queue_name, :tag, :assettype
 
     has_one :agent, serializer: Api::V1::AgentSerializer
     has_one :checktype, serializer: Api::V1::ChecktypeSerializer

--- a/db/migrate/20201028102229_add_assettypes_to_checks.rb
+++ b/db/migrate/20201028102229_add_assettypes_to_checks.rb
@@ -1,0 +1,5 @@
+class AddAssettypesToChecks < ActiveRecord::Migration[5.0]
+  def change
+    add_column :checks, :assettype, :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200603163948) do
+ActiveRecord::Schema.define(version: 20201028102229) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,6 +46,7 @@ ActiveRecord::Schema.define(version: 20200603163948) do
     t.string   "queue_name"
     t.string   "tag"
     t.text     "required_vars", default: [],                     array: true
+    t.string   "assettype"
     t.index ["agent_id"], name: "index_checks_on_agent_id", using: :btree
     t.index ["checktype_id"], name: "index_checks_on_checktype_id", using: :btree
     t.index ["scan_id"], name: "index_checks_on_scan_id", using: :btree

--- a/lib/scan_processor.rb
+++ b/lib/scan_processor.rb
@@ -37,7 +37,7 @@ class ScanProcessor
   def process_checks_array(event, event_data = nil)
     if event == :skey && event_data == 'check'
       @state.processor = method(:process_check)
-      @state.check = { checktype_id: '', checktype_name: '', target: '', options: '', webhook: '', tag:nil, jobqueue_id:nil, jobqueue_name:nil, required_vars: []}.with_indifferent_access
+      @state.check = { checktype_id: '', checktype_name: '', target: '', options: '', webhook: '', tag:nil, jobqueue_id:nil, jobqueue_name:nil, assettype: '', required_vars: []}.with_indifferent_access
     end
   end
 

--- a/lib/sqs_service.rb
+++ b/lib/sqs_service.rb
@@ -26,7 +26,8 @@ class SQSService
       "required_vars" => check.required_vars,
       "scan_id" => check.scan_id,
       "metadata" => metadata,
-      "start_time" => start_time
+      "start_time" => start_time,
+      "assettype" => check.assettype,
     }
 
     resp = @sqs.send_message({

--- a/test/unit/scan_processor_test.rb
+++ b/test/unit/scan_processor_test.rb
@@ -3,8 +3,8 @@ require 'test_helper'
 describe 'scan_processor' do
   it 'should process a scan' do
     checks_params = { scan: { checks: [
-      { check: { checktype_name: 'tls', target: 'localhost', tag:'tag1'}},
-      { check: { checktype_name: 'tls', target: 'www.example.com', tag:'tag2'}}
+      { check: { checktype_name: 'tls', target: 'localhost', tag: 'tag1'}},
+      { check: { checktype_name: 'tls', target: 'www.example.com', tag: 'tag2', assettype: 'Hostname'}}
     ]}}
     s = StringIO.new checks_params.to_json.to_s
     processor = ScanProcessor.new(Rails.logger, method(:check_parsed))
@@ -13,8 +13,8 @@ describe 'scan_processor' do
     end
 
     assert_equal(@checks,[
-                   { 'checktype_id' => '', 'checktype_name' => 'tls', 'target' => 'localhost', 'options' => '', 'webhook' => '', 'tag' => 'tag1', 'jobqueue_id' => nil, 'jobqueue_name' => nil, 'required_vars' => []},
-                   { 'checktype_id' => '', 'checktype_name' => 'tls', 'target' => 'www.example.com', 'options' => '', 'webhook' => '', 'tag' => 'tag2', 'jobqueue_id' => nil, 'jobqueue_name' => nil, 'required_vars' => []}
+                   { 'checktype_id' => '', 'checktype_name' => 'tls', 'target' => 'localhost', 'options' => '', 'webhook' => '', 'tag' => 'tag1', 'jobqueue_id' => nil, 'jobqueue_name' => nil, 'assettype' => '', 'required_vars' => []},
+                   { 'checktype_id' => '', 'checktype_name' => 'tls', 'target' => 'www.example.com', 'options' => '', 'webhook' => '', 'tag' => 'tag2', 'jobqueue_id' => nil, 'jobqueue_name' => nil, 'assettype' => 'Hostname', 'required_vars' => []}
                  ])
   end
   def check_parsed(check)


### PR DESCRIPTION
This PR allows propagating the asset type known at the Vulcan API level to the checks. Accepts the new attribute `assettype` when creating checks, and also embeds it to the checks queue for the agent.

### Create check without specifying the asset type

```
$ curl -H 'Content-type: application/json' https:/xxx/v1/checks --data '{ "check" : { "target" : "www.adevinta.com", "checktype_name" : "vulcan-http-headers" } }' | jq .

{
  "check": {
    "id": "22a2a1c2-dd65-4d48-8ee9-90cb061e619d",
    "target": "www.adevinta.com",
    "status": "CREATED",
...
    "assettype": null,
...
}
```

SQS message:
![image](https://user-images.githubusercontent.com/3331668/97460999-95b07100-193d-11eb-8ca9-f6933a80086b.png)

```
$ curl https://xxx/v1/checks/22a2a1c2-dd65-4d48-8ee9-90cb061e619d | jq .

{
  "check": {
    "id": "22a2a1c2-dd65-4d48-8ee9-90cb061e619d",
    "target": "www.adevinta.com",
    "status": "FINISHED",
...
    "assettype": null,
...
}
```
 
### Create check specifying the asset type

```
$ curl -H 'Content-type: application/json' https://xxx/v1/checks --data '{ "check" : { "target" : "www.adevinta.com", "checktype_name" : "vulcan-http-headers", "assettype" : "Hostname" } }' | jq .

{
  "check": {
    "id": "d473c4d1-a916-4ed2-8c0d-77df97b5be64",
    "target": "www.adevinta.com",
    "status": "CREATED",
...
    "assettype": "Hostname",
...
}
```

SQS message:
![image](https://user-images.githubusercontent.com/3331668/97461200-d14b3b00-193d-11eb-9c5d-67f02004c1f1.png)

```
$ curl https://xxx/v1/checks/d473c4d1-a916-4ed2-8c0d-77df97b5be64 | jq .

{
  "check": {
    "id": "d473c4d1-a916-4ed2-8c0d-77df97b5be64",
    "target": "www.adevinta.com",
    "status": "FINISHED",
...
    "assettype": "Hostname",
...
}
```