### PR TITLE
Fix async scan creation

### DIFF
--- a/lib/checks_helper.rb
+++ b/lib/checks_helper.rb
@@ -85,6 +85,9 @@ class ChecksHelper
           scan.tag = check.tag if check.tag
           scan.program = ScansHelper.normalize_program(program_id) if program_id
           scan.save
+        # If scan has already been created by another
+        # worker, continue.
+        rescue ActiveRecord::RecordNotUnique => e
         end
       end
     end
@@ -109,7 +112,7 @@ class ChecksHelper
         # by the persistence.
         return check
       end
-      unless scan.increment!(:size)
+      unless scan.increment!(:size) # DJS: Race condition incrementing scan size ?
         Rails.logger.error "error incrementing the size of the scan #{scan.id}"
         return nil
       end

--- a/lib/checks_helper.rb
+++ b/lib/checks_helper.rb
@@ -100,7 +100,7 @@ class ChecksHelper
       check = Check.find(check.id)
       return check
     end
-    # NOTE: take into account that increasing the scan size for every created chheck,
+    # NOTE: take into account that increasing the scan size for every created check,
     # is increasing the number of queries to database x3, as we are getting the scan
     # from the database and saving it again, for every created check.
     if check.scan_id
@@ -112,7 +112,7 @@ class ChecksHelper
         # by the persistence.
         return check
       end
-      unless scan.increment!(:size) # DJS: Race condition incrementing scan size ?
+      unless scan.increment_counter(:size)
         Rails.logger.error "error incrementing the size of the scan #{scan.id}"
         return nil
       end

--- a/lib/checks_helper.rb
+++ b/lib/checks_helper.rb
@@ -112,9 +112,11 @@ class ChecksHelper
         # by the persistence.
         return check
       end
-      unless scan.increment_counter(:size)
-        Rails.logger.error "error incrementing the size of the scan #{scan.id}"
-        return nil
+      scan.with_lock do
+        unless scan.increment!(:size)
+          Rails.logger.error "error incrementing the size of the scan #{scan.id}"
+          return nil
+        end
       end
     end
     check


### PR DESCRIPTION
This PR fixes race conditions in the scan creation and update during the asynchronous checks creation process.

The key point is that there is not a specific point for the scan data creation in persistence, instead the scan entity is created once the "first" check for the scan is processed. Therefore for each check a verification is made to know if the scan exists in the DB, otherwise it is created. This happens concurrently with N workers consuming and processing check messages from the queue, so there is a race condition for the creation of the scan when processing the first checks for it.

Example of race condition and PK error when trying to create the scan:

---- worker 1 starts processing check 1 of scan A
---- worker 1 verifies scan A is not in DB
---- worker 2 starts processing check 2 of scan A
---- worker 2 verifies scan A is not in DB
---- worker 1 creates scan A in DB successfully
---- worker 2 tries to create scan A in DB and fails (PK error on scan table)
    -> check 2 processing is aborted, **message will be processed correctly when it is consumed again from the queue.**

PK error happens on scan.save for checks_helper:
https://github.com/adevinta/vulcan-persistence/blob/06d9060245b93b7cbf82cbae60064923cadb2ac6/lib/checks_helper.rb#L81-L87

Also another possible race condition happens when incrementing the scan size:
https://github.com/adevinta/vulcan-persistence/blob/06d9060245b93b7cbf82cbae60064923cadb2ac6/lib/checks_helper.rb#L112

Apparently increment! performs two separate queries underneath, one to obtain the value and one to update it.
See: [this](https://stackoverflow.com/questions/14387022/atomic-insert-or-increment-in-activerecord-rails) and [this](https://stackoverflow.com/questions/11910974/how-do-i-consistently-increase-a-counter-cache-column).

NOTE: _increment_counter_ is not supported by or ROR version so we have to use [locking](https://guides.rubyonrails.org/active_record_querying.html#pessimistic-locking).