### PR TITLE
Break on error

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 
 # Copyright 2019 Adevinta
+
+set -e
+
 envsubst < .env.config > .env.production
 
 if [ -n "$POSTGRES_CA_B64" ]; then


### PR DESCRIPTION
The [vulcan-charts](https://github.com/adevinta/vulcan-charts/commit/a697c2e7319897b5c6b4e5b5f51ee6799fcdd8a7) removed the init container waiting for the db to be ready.  This relies on the container to manage this situation, either restarting or waiting for the db.

Allows to restart the container in case the db is not ready.