### PR TITLE
Fix nokogiri error on arm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ RUN apk add --no-cache \
     sqlite-dev \
     postgresql-client \
     gettext \
-    ca-certificates
+    ca-certificates \
+    gcompat
 
 COPY --from=pre-builder /gems/ /gems/
 ARG bundle_without rails_env


### PR DESCRIPTION
Fixes start error on arm

```
LoadError: Error loading shared library ld-linux-aarch64.so.1: No such file or directory (needed by /gems/ruby/3.3.0/gems/nokogiri-1.16.0-aarch64-linux/lib/nokogiri/3.3/nokogiri.so) - /gems/ruby/3.3.0/gems/nokogiri-1.16.0-aarch64-linux/lib/nokogiri/3.3/nokogiri.so
/gems/ruby/3.3.0/gems/nokogiri-1.16.0-aarch64-linux/lib/nokogiri/extension.rb:7:in `require_relative'
/gems/ruby/3.3.0/gems/nokogiri-1.16.0-aarch64-linux/lib/nokogiri/extension.rb:7:in `<top (required)>'
/gems/ruby/3.3.0/gems/nokogiri-1.16.0-aarch64-linux/lib/nokogiri.rb:8:in `require_relative'
/gems/ruby/3.3.0/gems/nokogiri-1.16.0-aarch64-linux/lib/nokogiri.rb:8:in `<top (required)>'
<internal:/usr/local/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
<internal:/usr/local/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
/app/config/application.rb:21:in `<top (required)>'
/app/Rakefile:6:in `require_relative'
/app/Rakefile:6:in `<top (required)>'
/gems/ruby/3.3.0/gems/rake-13.0.6/exe/rake:27:in `<top (required)>'
/usr/local/bin/bundle:25:in `load'
/usr/local/bin/bundle:25:in `<main>'
```


See https://nokogiri.org/tutorials/installing_nokogiri.html#linux-musl-error-loading-shared-library